### PR TITLE
Align version statements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = CASE-Implementation-PyPI-Exifread
-version = 0.1.1
+version = 0.1.2
 author = Robert Dowdall
 author_email = dowdallr@ucd.ie
 description = Case Implementation of some exifread functionality


### PR DESCRIPTION
I peeked at `exifread_case/exifread_case.py` and saw its `__version__` variable differed from `setup.cfg`.

This PR sets the version statements to match, manually at first.  It might be better to use the [extract-from-source pattern `case-utils` has used for a while](https://github.com/casework/CASE-Utilities-Python/blob/0.11.0/setup.cfg#L3).