### PR TITLE
Remove requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-exifread
-rdflib>=6.0.0
-case_utils


### PR DESCRIPTION
The package specifications in `requirements.txt` are covered by `setup.cfg`, but are also a bit out of sync.  (`case-utils` requires a more recent RDFLib version, and `setup.cfg` requires a more specific version of `case-utils`.)

I also did not see anywhere in the CI scripting where `requirements.txt` was brought in for e.g. virtual environment setup.

Thus, this patch is filed to remove the potential for package version conflicts.